### PR TITLE
Add a colour switch button for higher contrast

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -24,10 +24,6 @@ row:selected {
   color: @colorAccent;
 }
 
-link {
-    color: @colorAccent;
-}
-
 row:selected label {
     color: @theme_text_color;
 }

--- a/data/Application.css
+++ b/data/Application.css
@@ -21,7 +21,7 @@ row:selected {
 
 /* Label styling */
 .accent {
-  color: @colorAccent;
+  color: #e65c00;
 }
 
 row:selected label {
@@ -29,7 +29,7 @@ row:selected label {
 }
 
 row:selected .accent {
-    color: @colorAccent;
+    color: #e65c00;
 }
 
 /* Workaround for GTK Paned bug */

--- a/data/com.github.mdh34.hackup.gresource.xml
+++ b/data/com.github.mdh34.hackup.gresource.xml
@@ -2,5 +2,6 @@
 <gresources>
   <gresource prefix="/com/github/mdh34/hackup">
     <file alias="Application.css">Application.css</file>
+    <file alias="contrast.css">contrast.css</file>
   </gresource>
 </gresources>

--- a/data/com.github.mdh34.hackup.gschema.xml
+++ b/data/com.github.mdh34.hackup.gschema.xml
@@ -43,5 +43,10 @@
       <summary>dark mode state</summary>
       <description>stores the last known dark mode state</description>
     </key>
+    <key name="accent" type="b">
+      <default>true</default>
+      <summary>accent colour state</summary>
+      <description>stores the last known accent colour state</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/contrast.css
+++ b/data/contrast.css
@@ -1,0 +1,50 @@
+@define-color colorAccent #FF6600;
+
+/* Title label styling */
+.titlesize {
+    font-size: 14px;
+}
+
+/* ListBoxRow styling */
+row {
+    padding: 5px;
+    border-bottom: 1px solid #abacae;
+}
+
+row:selected {
+    background-color: #e6e6e6;
+}
+
+.dark row:selected {
+    background-color: #666666
+}
+
+/* Label styling */
+.accent {
+  color: @theme_text_color;
+}
+
+row:selected label {
+    color: @theme_text_color;
+}
+
+row:selected .accent {
+    color: @theme_text_color;
+}
+
+/* Workaround for GTK Paned bug */
+
+paned.horizontal > separator {
+    background-image:
+        linear-gradient(
+            to right,
+            @menu_separator 1px,
+            @menu_separator_shadow 1px,
+            @menu_separator_shadow 2px,
+            transparent 2px
+        );
+    margin-right: -7px;
+    min-width: 8px;
+    margin-top: -7px;
+    min-height: 8px;
+}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,8 +36,16 @@ public class HackUp : Gtk.Application {
 
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("/com/github/mdh34/hackup/Application.css");
-        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        
+        var contrast_provider = new Gtk.CssProvider ();
+        contrast_provider.load_from_resource ("/com/github/mdh34/hackup/contrast.css");
 
+        if (!settings.get_boolean ("accent")) {
+            change_provider (contrast_provider);
+        } else {
+            change_provider (provider);
+        }
+        
         var quit_action = new SimpleAction ("quit", null);
         add_action (quit_action);
         set_accels_for_action ("app.quit", {"<Control>q"});
@@ -49,5 +57,9 @@ public class HackUp : Gtk.Application {
     public static int main (string[] args) {
         var app = new HackUp ();
         return app.run (args);
+    }
+
+    public void change_provider (Gtk.CssProvider provider) {
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,11 +40,19 @@ public class HackUp : Gtk.Application {
         var contrast_provider = new Gtk.CssProvider ();
         contrast_provider.load_from_resource ("/com/github/mdh34/hackup/contrast.css");
 
-        if (!settings.get_boolean ("accent")) {
-            change_provider (contrast_provider);
-        } else {
+        if (settings.get_boolean ("accent")) {
             change_provider (provider);
+        } else {
+            change_provider (contrast_provider);
         }
+
+        settings.changed["accent"].connect(()=> {
+            if (settings.get_boolean ("accent")) {
+                change_provider (provider);
+            } else {
+                change_provider (contrast_provider);
+            }
+        });
         
         var quit_action = new SimpleAction ("quit", null);
         add_action (quit_action);

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -51,19 +51,30 @@ public class SettingsPopover : Gtk.Popover {
         var cookies_switch = new Gtk.Switch ();
         HackUp.settings.bind ("cookies", cookies_switch, "active", SettingsBindFlags.DEFAULT);
 
+        var contrast_switch = new Gtk.Switch ();
+        HackUp.settings.bind ("accent", contrast_switch, "active", SettingsBindFlags.DEFAULT);
+
         var cookies_label = new Gtk.Label (_("Cookies"));
         var switch_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
         switch_box.pack_start (cookies_label);
         switch_box.pack_start (cookies_switch);
 
+        var contrast_icon = new Gtk.Image.from_icon_name ("preferences-color", Gtk.IconSize.LARGE_TOOLBAR);
+        var contrast_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
+        contrast_box.homogeneous = true;
+        contrast_box.pack_start (contrast_icon);
+        contrast_box.pack_start (contrast_switch);
+
         var settings_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
         settings_box.border_width = 10;
+        settings_box.pack_start (contrast_box);
         settings_box.pack_start (switch_box);
         settings_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         settings_box.pack_start (settings_label);
         settings_box.pack_start (top_radio);
         settings_box.pack_start (best_radio);
         settings_box.pack_start (new_radio);
+        
         settings_box.show_all ();
         add (settings_box);
 


### PR DESCRIPTION
Fixes #23 
Allows switching between colour and monochrome for comment and vote labels:
![screenshot from 2018-11-21 18 23 58](https://user-images.githubusercontent.com/12615975/48861140-ccc59180-edba-11e8-9cf0-5dc77ee3738e.png)
![screenshot from 2018-11-21 18 24 06](https://user-images.githubusercontent.com/12615975/48861141-ccc59180-edba-11e8-90df-9dbeed90d59f.png)
