### PR TITLE
+ tabs in header bar, moved sections (top, best, new)

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,10 +40,25 @@ public class MainWindow : Gtk.Window {
         set_position (Gtk.WindowPosition.CENTER);
 
         var header = new Gtk.HeaderBar ();
-        header.get_style_context ().add_class ("default-decoration");
-        header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         header.set_show_close_button (true);
         set_titlebar (header);
+
+        var views_buttons = new Granite.Widgets.ModeButton ();
+        views_buttons.append_text (_ ("Top"));
+        views_buttons.append_text (_ ("Best"));
+        views_buttons.append_text (_ ("New"));
+        switch (HackUp.settings.get_string ("listtype")) {
+          case "top":
+            views_buttons.selected = 0;
+            break;
+          case "best":
+            views_buttons.selected = 1;
+            break;
+          case "new":
+            views_buttons.selected = 2;
+            break;
+        }
+        header.pack_start (views_buttons);
 
         if (!check_online ()) {
             var offline_view = new Granite.Widgets.AlertView (_("Unable to reach Hacker News"), _("Please connect to the internet to use HackUp"), "applications-internet");
@@ -100,8 +115,21 @@ public class MainWindow : Gtk.Window {
             list.get_style_context ().add_class ("dark");
         }
 
-        settings_popover.closed.connect (() => {
-            var list_sorting = HackUp.settings.get_string ("listtype");
+        views_buttons.mode_changed.connect (() => {
+          string list_sorting;
+          stdout.printf ("%d",views_buttons.selected);
+            switch (views_buttons.selected) {
+              case 0:
+                list_sorting = "top";
+                break;
+              case 1:
+                list_sorting = "best";
+                break;
+              case 2:
+                list_sorting = "new";
+                break;
+            }
+            HackUp.settings.set_string ("listtype", list_sorting);
             if (settings_popover.current_sort != list_sorting) {
                 var new_list = new PostList ();
                 scroller.remove (scroller.get_child ());

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,6 +40,8 @@ public class MainWindow : Gtk.Window {
         set_position (Gtk.WindowPosition.CENTER);
 
         var header = new Gtk.HeaderBar ();
+        header.get_style_context ().add_class ("default-decoration");
+        header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         header.set_show_close_button (true);
         set_titlebar (header);
 

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -21,33 +21,6 @@
 public class SettingsPopover : Gtk.Popover {
     public string current_sort;
     public SettingsPopover (View view) {
-        current_sort = HackUp.settings.get_string ("listtype");
-        var settings_label = new Gtk.Label (_("Sort stories by:"));
-        var top_radio = new Gtk.RadioButton.with_label (null, _("Top"));
-        top_radio.toggled.connect (() => {
-            toggled ("top");
-        });
-        var best_radio = new Gtk.RadioButton.with_label_from_widget (top_radio, _("Best"));
-        best_radio.toggled.connect (() => {
-            toggled ("best");
-        });
-        var new_radio = new Gtk.RadioButton.with_label_from_widget (top_radio, _("New"));
-        new_radio.toggled.connect (() => {
-            toggled ("new");
-        });
-
-        switch (current_sort) {
-            case "top":
-                top_radio.active = true;
-                break;
-            case "best":
-                best_radio.active = true;
-                break;
-            case "new":
-                new_radio.active = true;
-                break;
-        }
-
         var cookies_switch = new Gtk.Switch ();
         HackUp.settings.bind ("cookies", cookies_switch, "active", SettingsBindFlags.DEFAULT);
 
@@ -70,10 +43,6 @@ public class SettingsPopover : Gtk.Popover {
         settings_box.pack_start (contrast_box);
         settings_box.pack_start (switch_box);
         settings_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        settings_box.pack_start (settings_label);
-        settings_box.pack_start (top_radio);
-        settings_box.pack_start (best_radio);
-        settings_box.pack_start (new_radio);
         
         settings_box.show_all ();
         add (settings_box);
@@ -81,9 +50,5 @@ public class SettingsPopover : Gtk.Popover {
         this.closed.connect (() => {
             view.setup_cookies (cookies_switch.active);
         });
-    }
-
-    private void toggled (string new_sort) {
-        HackUp.settings.set_string ("listtype", new_sort);
     }
 }


### PR DESCRIPTION
![screenshot from 2019-03-05 22 42 51](https://user-images.githubusercontent.com/23294184/53839532-0bf9a600-3f98-11e9-9797-1028cfc47cff.png)
As you can see from the image, i moved the ordering of the posts in the header bar to provide a more consistent experience with the rest of the system