### PR TITLE
+"tree view" of comments +fixed memory leak of comments view

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -21,6 +21,7 @@
 
 public class MainWindow : Gtk.Window {
     static View view;
+    public static Gtk.ScrolledWindow comments_view;
     public static Gtk.Stack stack;
     public MainWindow (Gtk.Application application) {
         Object (
@@ -32,8 +33,10 @@ public class MainWindow : Gtk.Window {
 
     static construct {
         view = new View ();
+        comments_view = new Gtk.ScrolledWindow (null,null);
         stack = new Gtk.Stack ();
         stack.add_named (view, "view");
+        stack.add_named (comments_view, "comments_view");
     }
 
     construct {

--- a/src/Widgets/CommentsEntry.vala
+++ b/src/Widgets/CommentsEntry.vala
@@ -50,6 +50,10 @@ public class CommentEntry : Gtk.ListBoxRow {
 
     public CommentEntry (int64 id, int64 last, Gtk.SizeGroup author_group) {
         author_label = new Gtk.Label (null);
+        author_label.xalign = 0;
+        var author_context = author_label.get_style_context ();
+        author_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        author_context.add_class (Granite.STYLE_CLASS_ACCENT);
         author_group.add_widget (author_label);
 
         selectable = false;

--- a/src/Widgets/CommentsEntry.vala
+++ b/src/Widgets/CommentsEntry.vala
@@ -52,6 +52,8 @@ public class CommentEntry : Gtk.ListBoxRow {
         author_label = new Gtk.Label (null);
         author_group.add_widget (author_label);
 
+        selectable = false;
+
         content_label = new Gtk.TextView ();
         content_label.wrap_mode = Gtk.WrapMode.WORD;
         content_label.editable = false;

--- a/src/Widgets/CommentsEntry.vala
+++ b/src/Widgets/CommentsEntry.vala
@@ -44,20 +44,19 @@ public class CommentEntry : Gtk.ListBoxRow {
 
     private Gtk.Label author_label;
     private Gtk.TextView content_label;
-    private Gtk.Button sub_button;
+    private Gtk.CheckButton sub_button;
     private Gtk.Box info_box;
+    private Gtk.Revealer revealer;
 
     public CommentEntry (int64 id, int64 last, Gtk.SizeGroup author_group) {
         author_label = new Gtk.Label (null);
-        author_label.xalign = 0;
-        var author_context = author_label.get_style_context ();
-        author_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
-        author_context.add_class (Granite.STYLE_CLASS_ACCENT);
         author_group.add_widget (author_label);
 
         content_label = new Gtk.TextView ();
         content_label.wrap_mode = Gtk.WrapMode.WORD;
         content_label.editable = false;
+
+        revealer = new Gtk.Revealer ();
 
         this.activate.connect (() => {
             if (post.story_uri != null) {
@@ -65,13 +64,16 @@ public class CommentEntry : Gtk.ListBoxRow {
             }
         });
 
-        sub_button = new Gtk.Button.with_label (_("Replies"));
-        sub_button.clicked.connect (() => {
-            if (MainWindow.stack.get_child_by_name (post.id.to_string ()) == null) {
-                MainWindow.stack.add_named (new CommentsList (post, last), post.id.to_string ());
-            }
-            MainWindow.stack.set_visible_child_name (post.id.to_string ());
-            MainWindow.stack.show_all ();
+        sub_button = new Gtk.CheckButton.with_label (_("Replies"));
+        sub_button.toggled.connect (() => {
+                if (revealer.get_child () == null) {
+                  revealer.add (new CommentsList (post, last));
+                }
+                if (sub_button.active) {
+                  revealer.reveal_child = true; 
+                } else {
+                  revealer.reveal_child = false;
+                }
         });
 
         info_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
@@ -81,6 +83,7 @@ public class CommentEntry : Gtk.ListBoxRow {
         var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
         box.pack_start (content_label);
         box.pack_start (info_box,true, true);
+        box.pack_start (revealer);
         add (box);
 
         post = new Post (id);

--- a/src/Widgets/CommentsList.vala
+++ b/src/Widgets/CommentsList.vala
@@ -19,39 +19,16 @@
  * Authored by: Matt Harris <matth281@outlook.com>
  */
 
-public class CommentsList : Gtk.ScrolledWindow {
+public class CommentsList : Gtk.ListBox {
     private Gtk.SizeGroup author_group;
-    private Gtk.Label last_label;
-    private Gtk.ListBox comments_box;
     private Post post;
     public CommentsList (Post parent, int64 last) {
         post = parent;
         author_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
 
-        var back_button = new Gtk.Button.with_label (_("Back"));
-        back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
-        if (last == parent.id) {
-            back_button.no_show_all = true;
-        } else {
-            back_button.clicked.connect (() => {
-                MainWindow.stack.set_visible_child_name (last.to_string ());
-            });
+        if (last != parent.id) {
+          margin_start = 20;
         }
-
-        last_label = new Gtk.Label (_("Replies to ") + post.author);
-
-        var top_bar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
-        top_bar.pack_start (back_button, false, false);
-        top_bar.pack_start (last_label);
-
-        comments_box = new Gtk.ListBox ();
-        comments_box.activate_on_single_click = true;
-        comments_box.set_selection_mode (Gtk.SelectionMode.NONE);
-
-        var container = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
-        container.pack_start (top_bar, false, false);
-        container.pack_start (comments_box);
-        add (container);
 
         load.begin ();
     }
@@ -60,13 +37,7 @@ public class CommentsList : Gtk.ScrolledWindow {
         int64[] list = {};
         list = post.get_children ();
         for (int i = 0; i < list.length; i++) {
-            comments_box.add (new CommentEntry (list[i], post.id, author_group));
-        }
-
-        foreach (Gtk.Widget child in get_children ()) {
-            if (child.visible == false) {
-                remove (child);
-            }
+            add (new CommentEntry (list[i], post.id, author_group));
         }
 
         show_all ();

--- a/src/Widgets/PostEntry.vala
+++ b/src/Widgets/PostEntry.vala
@@ -40,10 +40,11 @@ public class PostEntry : Gtk.ListBoxRow {
 
         comments_button = new Gtk.Button();
         comments_button.clicked.connect (() => {
-            if (MainWindow.stack.get_child_by_name (post.id.to_string ()) == null) {
-                MainWindow.stack.add_named (new CommentsList (post, post.id), post.id.to_string ());
+            if (MainWindow.comments_view.get_child () != null) {
+              MainWindow.comments_view.get_child ().destroy (); 
             }
-            MainWindow.stack.set_visible_child_name (post.id.to_string ());
+            MainWindow.comments_view.add (new CommentsList (post, post.id));
+            MainWindow.stack.set_visible_child_name ("comments_view");
             MainWindow.stack.show_all ();
         });
         var comments_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);


### PR DESCRIPTION
With this commit you can now browse comments by expanding them and showing the replies.
When a comment is expanded also has a nice reveal animation provided by ```Gtk.Revealer```.
This should solve #13 

Before this commit, every time you loaded a post's comments,
the program created a new view and switched to it.
Now there is only one "comment_view" and it is populated
when needed.

