### PR TITLE
Added Flatpak manifest for Elementary.

### DIFF
--- a/com.github.mdh34.hackup.yml
+++ b/com.github.mdh34.hackup.yml
@@ -1,0 +1,24 @@
+---
+app-id: com.github.mdh34.hackup
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+command: com.github.mdh34.hackup
+finish-args:
+- "--share=ipc"
+- "--share=network"
+- "--device=dri"
+- "--socket=x11"
+- "--socket=wayland"
+- "--metadata=X-DConf=migrate-path=/com/github/mdh34/hackup/"
+modules:
+- name: hackup
+  buildsystem: meson
+  config-opts:
+  - "--buildtype=release"
+  sources:
+  - type: archive
+    url: https://github.com/mdh34/hackup/archive/1.1.8.tar.gz
+    sha256: c2391d56f0413803be329dd1942132fd9ddc1021649868e61281d8dccffe2b1b
+
+


### PR DESCRIPTION
This is a modified version of the Flathub manifest so that it can be built using the Elementary OS 6.0 AppCenter.